### PR TITLE
Use Marathon event stream instead of subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ The proxymatic image forms one part of a network level service discovery solutio
 ## Environment Variables
 
  * **MARATHON_URL** - List of Marathon replicas, e.g. "http://marathon-01:8080/,http://marathon-02:8080/"
- * **MARATHON_CALLBACK_URL** - URL to register for Marathon HTTP callbacks, e.g. "http://\`hostname -f\`:5090/"
  * **REGISTRATOR_URL** - URL where registrator publishes services, e.g. "etcd://localhost:4001/services"
  * **REFRESH_INTERVAL=60** - Polling interval when using non-event capable backends. Defaults to 60 seconds.
  * **EXPOSE_HOST=false** - Expose services running in net=host mode. May cause port collisions when this container is also run in net=host mode. Defaults to false.
@@ -25,9 +24,6 @@ Options:
   -m MARATHON, --marathon=MARATHON
                         List of Marathon replicas, e.g.
                         "http://marathon-01:8080/,http://marathon-02:8080/"
-  -c CALLBACK, --marathon-callback=CALLBACK
-                        URL to register for Marathon HTTP callbacks, e.g.
-                        "http://`hostname -f`:5090/"
   -r REGISTRATOR, --registrator=REGISTRATOR
                         URL where registrator publishes services, e.g. "etcd
                         ://etcd-host:4001/services"
@@ -56,12 +52,12 @@ Options:
 
 ## Marathon
 
-Given a Marathon URL, proxymatic will periodically fetch the running tasks and configure proxies that forward connections from the [servicePort](http://mesosphere.com/docs/getting-started/service-discovery/) to the host and port exposed by the task. If Marathon is started with [HTTP callback support](https://mesosphere.github.io/marathon/docs/event-bus.html) then proxymatic can be notified immediately, which cuts the response time in case of failover or scaling.
+Given a Marathon URL, proxymatic will fetch the running tasks and configure proxies that forward connections from the [servicePort](http://mesosphere.com/docs/getting-started/service-discovery/) to the host and port exposed by the task. Proxymatic subscribes to the [Marathon event bus](https://mesosphere.github.io/marathon/docs/event-bus.html) 
+and receive cluster changes immediately when they occur, which cuts the response time in case of failover or scaling.
 
 ```
 docker run --net=host \
   -e MARATHON_URL=http://marathon-host:8080 \
-  -e MARATHON_CALLBACK_URL=http://$(hostname --fqdn):5090 \
   meltwater/proxymatic:latest
 ```
 
@@ -176,11 +172,10 @@ RestartSec=15
 
 ExecStartPre=-/usr/bin/docker kill $NAME
 ExecStartPre=-/usr/bin/docker rm $NAME
-ExecStartPre=-/bin/sh -c 'if ! docker images | tr -s " " : | grep "^${IMAGE}:"; then docker pull "${IMAGE}"; fi'
+ExecStartPre=-/usr/bin/docker pull $IMAGE
 ExecStart=/usr/bin/docker run --net=host \
     --name=${NAME} \
     -e MARATHON_URL=http://marathon-host:8080 \
-    -e MARATHON_CALLBACK_URL=http://%H:5090 \
     $IMAGE
 
 ExecStop=/usr/bin/docker stop $NAME
@@ -203,5 +198,4 @@ docker::run_instance:
     net: 'host'
     env:
       - "MARATHON_URL=http://marathon-host:8080"
-      - "MARATHON_CALLBACK_URL=http://%{::hostname}:5090"
 ```

--- a/src/backend/aggregate.py
+++ b/src/backend/aggregate.py
@@ -1,13 +1,12 @@
 import logging, threading
 
 class AggregateBackend(object):
-    def __init__(self, exposehost, ignoreports):
+    def __init__(self, exposehost):
         self._exposehost = exposehost
         self._backends = []
         self._sources = {}
         self._lock = threading.RLock()
         self._prev = {}
-        self._ignoreports = ignoreports
     
     def add(self, backend):
         self._backends.append(backend)
@@ -61,9 +60,5 @@ class AggregateBackend(object):
         for server in service.servers:
             if not self._exposehost and server.port == str(service.port):
                 return False
-        
-        # Filter the Marathon HTTP callback port
-        if service.port in self._ignoreports:
-            return False
         
         return True

--- a/src/main.py
+++ b/src/main.py
@@ -37,7 +37,7 @@ def parselist(value):
         
 parser.add_option('-m', '--marathon', dest='marathon', help='List of Marathon replicas, e.g. "http://marathon-01:8080/,http://marathon-02:8080/"',
     default=os.environ.get('MARATHON_URL', ''))
-parser.add_option('-c', '--marathon-callback', dest='callback', help='URL to listen for Marathon HTTP callbacks, e.g. "http://`hostname -f`:5090/"',
+parser.add_option('-c', '--marathon-callback', dest='callback', help='[DEPRECATED] URL to listen for Marathon HTTP callbacks, e.g. "http://`hostname -f`:5090/"',
     default=os.environ.get('MARATHON_CALLBACK_URL', None))
     
 parser.add_option('-r', '--registrator', dest='registrator', help='URL where registrator publishes services, e.g. "etcd://etcd-host:4001/services"',
@@ -80,12 +80,7 @@ if not options.registrator and not options.marathon:
     parser.print_help()
     sys.exit(1)
 
-# Fetch port to listen for Marathon callbacks
-callbackport = None
-if options.callback:
-	callbackurl = urlparse(options.callback)
-	callbackport = callbackurl.port or 80
-backend = AggregateBackend(options.exposehost, set([callbackport]))
+backend = AggregateBackend(options.exposehost)
 
 if options.vhostdomain:
     backend.add(NginxBackend(options.vhostport, options.vhostdomain, options.proxyprotocol, options.maxconnections))
@@ -106,7 +101,7 @@ if options.registrator:
     registrator.start()
 
 if options.marathon:
-    marathon = MarathonDiscovery(backend, parselist(options.marathon), options.callback, options.interval)
+    marathon = MarathonDiscovery(backend, parselist(options.marathon), options.interval)
     marathon.start()
 
 # Loop forever and allow the threads to work. Setting the threads to daemon=False and returning 

--- a/src/util.py
+++ b/src/util.py
@@ -92,11 +92,13 @@ class UnixHTTPConnection(httplib.HTTPConnection):
         sock.connect(self.path)
         self.sock = sock
 
-def unixrequest(method, socketpath, url, body=None, headers={}):
+def unixresponse(method, socketpath, url, body=None, headers={}):
     conn = UnixHTTPConnection(socketpath)
     conn.request(method, url, body, headers)
-    resp = conn.getresponse()
-    return resp.read()
+    return conn.getresponse()
+
+def unixrequest(method, socketpath, url, body=None, headers={}):
+    return unixresponse(method, socketpath, url, body, headers).read()
 
 def renderTemplate(src, dst, vals):
     template = Template(filename=src)


### PR DESCRIPTION
This uses the [Marathon even bus](https://mesosphere.github.io/marathon/docs/event-bus.html) which sends events via a long-lived HTTP connection. This requires Marathon 0.11.0+ which has been available since 1 Oct 2015

This also remotes the HTTP callback mechanism where Marathon would call out to Proxymatic. The --marathon-callback-url command line flag is kept for compatibility, but it does nothing.