### PR TITLE
Added /status endpoint to coordinate graceful restarts with upstream …

### DIFF
--- a/src/backend/haproxy.py
+++ b/src/backend/haproxy.py
@@ -2,9 +2,9 @@ import logging
 from proxymatic.util import *
 
 class HAProxyBackend(object):
-    def __init__(self, maxconnections, haproxystatus):
+    def __init__(self, maxconnections, statusendpoint):
         self._maxconnections = maxconnections
-        self._haproxystatus = haproxystatus
+        self._statusendpoint = statusendpoint
         self._prev = {}
         self._cfgfile = '/etc/haproxy/haproxy.cfg'
         self._render({})
@@ -38,4 +38,4 @@ class HAProxyBackend(object):
         renderTemplate('/etc/haproxy/haproxy.cfg.tpl', self._cfgfile, {
             'services': accepted,
             'maxconnections': self._maxconnections,
-            'statusbind': self._haproxystatus})
+            'statusendpoint': self._statusendpoint})

--- a/src/discovery/aggregate.py
+++ b/src/discovery/aggregate.py
@@ -1,0 +1,13 @@
+class AggregateDiscovery(object):
+    def __init__(self):
+        self._sources = []
+    
+    def add(self, source):
+        self._sources.append(source)
+
+    def isHealthy(self):
+        for source in self._sources:
+            if not source.isHealthy():
+                return False
+        
+        return len(self._sources) > 0

--- a/src/discovery/marathon.py
+++ b/src/discovery/marathon.py
@@ -20,6 +20,7 @@ class MarathonDiscovery(object):
         self._urls = [url.rstrip('/') for url in urls]
         self._socketpath = '/tmp/marathon.sock'
         self._interval = interval
+        self._healthy = False
         self._marathonService = MarathonService()
         self.priority = 10
         
@@ -30,6 +31,9 @@ class MarathonDiscovery(object):
 
         # Ensure the HAproxy load balancer is configured to proxy to the Marathon replicas
         self._connect()
+
+    def isHealthy(self):
+        return self._healthy
 
     def start(self):
         marathon = self
@@ -108,6 +112,9 @@ class MarathonDiscovery(object):
         self._backend.update(self, self._parse(response))
         logging.debug("Refreshed services from Marathon at %s", self._urls)
 
+        # Signal that we're up and running
+        self._healthy = True
+
     def _parse(self, content):
         services = {}
 
@@ -181,4 +188,3 @@ class MarathonDiscovery(object):
                     logging.debug(traceback.format_exc())
         
         return services
-        

--- a/src/status.py
+++ b/src/status.py
@@ -1,0 +1,42 @@
+import logging
+from urlparse import urlparse
+from BaseHTTPServer import BaseHTTPRequestHandler
+from proxymatic.util import *
+
+class StatusEndpoint(object):
+    def __init__(self, source):
+        self._source = source
+        self._terminate = False
+
+    def start(self):
+        status = self
+
+        class RequestHandler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                if self.path == '/status':
+                    if status._terminate:
+                        code, message = 503, "TERMINATING\n"
+                    elif status._source.isHealthy():
+                        code, message = 200, "OK\n"
+                    else:
+                        code, message = 503, "INITIALIZING\n"
+
+                    self.send_response(code)
+                    self.end_headers()
+                    self.wfile.write(message)
+                else:
+                    self.send_error(404)
+
+            def log_request(self, *args, **kwargs):
+                # Ignore request logging for status checks
+                pass
+
+        server = UnixHTTPServer('/tmp/proxymatic-status.sock', RequestHandler)
+        run(server.serve_forever, "Error serving HTTP status endpoint")
+        logging.debug("Enabled /status endpoint on /tmp/proxymatic-status.sock")
+
+    def terminate(self):
+        self._terminate = True
+
+    def isTerminating(self):
+        return self._terminate

--- a/src/util.py
+++ b/src/util.py
@@ -1,4 +1,6 @@
 import logging, os, re, signal, time, threading, traceback, urllib2, httplib, socket, subprocess, random
+from SocketServer import ThreadingMixIn
+from BaseHTTPServer import HTTPServer
 from mako.template import Template
 
 def post(url, data='{}'):
@@ -101,6 +103,14 @@ class UnixHTTPConnection(httplib.HTTPConnection):
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         sock.connect(self.path)
         self.sock = sock
+
+class UnixHTTPServer(ThreadingMixIn, HTTPServer):
+    address_family = socket.AF_UNIX
+
+    def get_request(self):
+        # Client address is expected to be (ip, port) which is not what a unix socket returns
+        request, client_address = HTTPServer.get_request(self)
+        return request, ('127.0.0.1', '0')
 
 def unixresponse(method, socketpath, url, body=None, headers={}):
     conn = UnixHTTPConnection(socketpath)


### PR DESCRIPTION
Added /status endpoint to coordinate graceful restarts with upstream load balancers
* Proxymatic traps SIGTERM and starts failing the health check to signal upstream load balancers to remove it from rotation. 
* Proxymatic will still continue to serve traffic until SIGKILL'ed by Docker after the `docker stop --time=x` which should be longer than the drain timeout in the upstream load balancer.
* On startup Proxymatic doesn't enter become healthy until it's refreshed from Marathon at least once. This helps avoid injecting faulty instances into upstream load balancers on startup.

@rasjoh @dezmodue please review
