### PR TITLE
Expose service name and port from Marathon to the stats endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The proxymatic image forms one part of a network level service discovery solutio
  * **STATUS_ENDPOINT=0.0.0.0:9090** - Expose /status endpoint and HAproxy stats on this ip:port
  * **REFRESH_INTERVAL=60** - Polling interval when using non-event capable backends. Defaults to 60 seconds.
  * **EXPOSE_HOST=false** - Expose services running in net=host mode. May cause port collisions when this container is also run in net=host mode. Defaults to false.
- * **HAPROXY=true** - Use HAproxy for TCP services instead of running everything through Pen. Defaults to false.
+ * **HAPROXY=true** - Use HAproxy for TCP services instead of running everything through Pen. Defaults to true.
  * **VHOST_DOMAIN** - Enables nginx with virtual hosts for each service under this domain, e.g. "services.example.com"
  * **VHOST_PORT=80** - Port to serve virtual hosts from. Defaults to port 80.
  * **PROXY_PROTOCOL=false** - Enable proxy protocol on the nginx vhost which is needed when using the AWS ELB in TCP mode for websocket support.

--- a/haproxy.cfg.tpl
+++ b/haproxy.cfg.tpl
@@ -73,7 +73,7 @@ frontend stats
 
 % for service in services.values():
 # ${service.name} (${service.source})
-listen ${service.name}-${service.portname}
+listen ${service.marathonpath}-${service.portname}
 % if service.protocol == 'unix':
   bind unix@${service.port}
 % else:

--- a/haproxy.cfg.tpl
+++ b/haproxy.cfg.tpl
@@ -73,7 +73,7 @@ frontend stats
 
 % for service in services.values():
 # ${service.name} (${service.source})
-listen service-${service.portname}
+listen ${service.name}-${service.portname}
 % if service.protocol == 'unix':
   bind unix@${service.port}
 % else:
@@ -85,9 +85,9 @@ listen service-${service.portname}
   option httpchk GET ${service.healthcheckurl}
 % endif
   default-server inter 15s
-% 	for server, i in zip(service.slots, range(len(service.slots))):
+% 	for server in service.slots:
 %     if server:
-  server backend-${service.portname}-${i} ${server.ip}:${server.port}${' check' if service.healthcheck else ''}
+  server backend-${server.hostname}-${server.port} ${server.ip}:${server.port}${' check' if service.healthcheck else ''}
 %     endif
 % 	endfor  
 

--- a/src/discovery/marathon.py
+++ b/src/discovery/marathon.py
@@ -100,7 +100,7 @@ class MarathonDiscovery(object):
 
             # Resolve hostnames since HAproxy wants IP addresses
             ipaddr = socket.gethostbyname(parsed.hostname or '127.0.0.1')
-            server = Server(ipaddr, parsed.port or 80)
+            server = Server(ipaddr, parsed.port or 80, parsed.hostname)
             service._add(server)
 
         self._backend.update(self._marathonService, {self._socketpath: service})
@@ -176,7 +176,7 @@ class MarathonDiscovery(object):
 
                     # Resolve hostnames since HAproxy wants IP addresses
                     ipaddr = socket.gethostbyname(task['host'])
-                    server = Server(ipaddr, exposedPort)
+                    server = Server(ipaddr, exposedPort, task['host'])
                     
                     # Append backend to service
                     if key not in services:

--- a/src/discovery/registrator.py
+++ b/src/discovery/registrator.py
@@ -50,7 +50,7 @@ class RegistratorEtcdDiscovery(object):
                     # Resolve hostnames since HAproxy wants IP addresses
                     endpoint = backend['value'].split(':')
                     ipaddr = socket.gethostbyname(endpoint[0])
-                    server = Server(ipaddr, endpoint[1])
+                    server = Server(ipaddr, endpoint[1], endpoint[0])
             
                     # Append backend to service
                     if key not in services:

--- a/src/services.py
+++ b/src/services.py
@@ -2,10 +2,11 @@ import re
 from random import randint
 
 class Server(object):
-    def __init__(self, ip, port):
+    def __init__(self, ip, port, hostname):
         self.ip = ip
         self.port = port
-        
+        self.hostname = hostname
+
     def __cmp__(self, other):
         if not isinstance(other, Server):
             return -1

--- a/src/services.py
+++ b/src/services.py
@@ -63,6 +63,16 @@ class Service(object):
     def portname(self):
         return re.sub('[^a-zA-Z0-9]', '_', str(self.port))
 
+    @property
+    def marathonpath(self):
+        ret = ''
+        for s in self.name.split('.'):
+            if ret is not '':
+                ret = s +'_' + ret
+            else:
+                ret = s
+        return ret
+
     def update(self, other):
         """
         Returns an new updated Service object


### PR DESCRIPTION
Use the service-name from marathon for each service
Remove arbitrary counter, replace with allocated port per container
Add hostname to backend services