### PR TITLE
implement support for TASK_KILLING state in Marathon

### DIFF
--- a/src/discovery/marathon.py
+++ b/src/discovery/marathon.py
@@ -142,6 +142,11 @@ class MarathonDiscovery(object):
             servicePorts = task.get('servicePorts', [])
             seenServicePorts = set()
 
+            # Skip tasks that are being killed
+            if task.get('state') == 'TASK_KILLING':
+                logging.debug("Skipping task %s as it's currently being killed", task.get('id'))
+                continue
+
             for servicePort, portIndex in zip(servicePorts, range(len(servicePorts))):
                 protocol = 'tcp'
                 key = '%s/%s' % (servicePort, protocol.lower())


### PR DESCRIPTION
Prerequisites:

- Mesos 1.0+
- Marathon 1.3+
- `--enable_features task_killing` command line flag passed to Marathon
- `taskKillGracePeriodSeconds` set in your app definition

Marathon will send `status_update_event` events with `"task_status": "TASK_KILLING"` over the event bus, and the tasks API will set the state of tasks about to be killed to `TASK_KILLING`.

This change will take out all tasks with state `TASK_KILLING` out of the load balancer, enabling better handling of scaling events.
