### PR TITLE
Support overriding load balancer options

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The proxymatic image forms one part of a network level service discovery solutio
  * **VHOST_DOMAIN** - Enables nginx with virtual hosts for each service under this domain, e.g. "services.example.com"
  * **VHOST_PORT=80** - Port to serve virtual hosts from. Defaults to port 80.
  * **PROXY_PROTOCOL=false** - Enable proxy protocol on the nginx vhost which is needed when using the AWS ELB in TCP mode for websocket support.
+ * **GROUP_SIZE=1** - Number of Proxymatic instances serving this cluster. Per container connection limits are divided by this number to ensure a globally coordinated maxconn per container.
 
 ## Command Line Usage
 
@@ -34,13 +35,17 @@ Options:
   -i INTERVAL, --refresh-interval=INTERVAL
                         Polling interval in seconds when using non-event
                         capable backends [default: 60]
-  -e, --expose-host     Expose services running in net=host mode. May cause
-                        port collisions when this container is also run in
-                        net=host mode on the same machine [default: False]
+  -e, --expose-host     Expose services running in net=host mode [default:
+                        False]
   --status-endpoint=STATUSENDPOINT
                         Expose /status endpoint and HAproxy stats on this
                         ip:port [default: 0.0.0.0:9090]. Specify an empty
                         string to disable this endpoint
+  --group-size=GROUPSIZE
+                        Number of Proxymatic instances serving this cluster.
+                        Per container connection limits are divided by this
+                        number to ensure a globally coordinated maxconn per
+                        container [default: 1]
   --max-connections=MAXCONNECTIONS
                         Max number of connection per service [default: 8192]
   --pen-servers=PENSERVERS

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Applications may set Marathon labels to override load balancer settings for each
   "labels": {
     "com.meltwater.proxymatic.0.servicePort": "1234",
     "com.meltwater.proxymatic.0.weight": "100",
+    "com.meltwater.proxymatic.0.maxconn": "200",
     "com.meltwater.proxymatic.0.mode": "http"
   }
 ```
@@ -169,8 +170,9 @@ Applications may set Marathon labels to override load balancer settings for each
 | Label   |  |
 | :----------------- | :---------- |
 | com.meltwater.proxymatic.&lt;N&gt;.servicePort | Override the service port for this exposed container port |
-| com.meltwater.proxymatic.&lt;N&gt;.weight | Specify the load balancer weight for this port in the range `1-1000`. Default value is `500`. |
-| com.meltwater.proxymatic.&lt;N&gt;.mode | Specify the load balancer mode for this port as either `tcp` or `http`. Default is `tcp` mode. |
+| com.meltwater.proxymatic.&lt;N&gt;.weight | Weight for the containers of this app version in the range `1-1000`. Default value is `500`. |
+| com.meltwater.proxymatic.&lt;N&gt;.maxconn | Maximum concurrent connections per container. |
+| com.meltwater.proxymatic.&lt;N&gt;.mode | Load balancer mode for this port as either `tcp` or `http`. Default is `tcp` mode. |
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,24 @@ container host. Each service will automatically get a vhost under the app.exampl
 | http://myservice.app.example.com | myservice | myservice |
 | http://service.system.product.app.example.com | /product/system/service | service.system.product |
 
+## Application Settings
+
+Applications may set Marathon labels to override load balancer settings for each of their ports, where N = 0..number-of-exposed-ports. For example
+
+```
+  "labels": {
+    "com.meltwater.proxymatic.0.servicePort": "1234",
+    "com.meltwater.proxymatic.0.weight": "100",
+    "com.meltwater.proxymatic.0.mode": "http"
+  }
+```
+
+| Label   |  |
+| :----------------- | :---------- |
+| com.meltwater.proxymatic.&lt;N&gt;.servicePort | Override the service port for this exposed container port |
+| com.meltwater.proxymatic.&lt;N&gt;.weight | Specify the load balancer weight for this port in the range `1-1000`. Default value is `500`. |
+| com.meltwater.proxymatic.&lt;N&gt;.mode | Specify the load balancer mode for this port as either `tcp` or `http`. Default is `tcp` mode. |
+
 ## Deployment
 
 ### Graceful Shutdown

--- a/haproxy.cfg.tpl
+++ b/haproxy.cfg.tpl
@@ -87,7 +87,7 @@ listen ${service.marathonpath}-${service.portname}
   default-server inter 15s
 % 	for server in service.slots:
 %     if server:
-  server backend-${server.hostname}-${server.port} ${server.ip}:${server.port} weight ${int(float(server.weight) / 1000.0 * 256.0)}${' check' if service.healthcheck else ''}
+  server backend-${server.hostname}-${server.port} ${server.ip}:${server.port} weight ${int(float(server.weight) / 1000.0 * 256.0)}${' maxconn %s' % server.maxconn if server.maxconn else ''}${' check' if service.healthcheck else ''}
 %     endif
 % 	endfor  
 

--- a/haproxy.cfg.tpl
+++ b/haproxy.cfg.tpl
@@ -87,7 +87,7 @@ listen ${service.marathonpath}-${service.portname}
   default-server inter 15s
 % 	for server in service.slots:
 %     if server:
-  server backend-${server.hostname}-${server.port} ${server.ip}:${server.port}${' check' if service.healthcheck else ''}
+  server backend-${server.hostname}-${server.port} ${server.ip}:${server.port} weight ${int(float(server.weight) / 1000.0 * 256.0)}${' check' if service.healthcheck else ''}
 %     endif
 % 	endfor  
 

--- a/nginx.tpl
+++ b/nginx.tpl
@@ -104,8 +104,9 @@ http {
     % for service in services.values():
     # ${service.name} (${service.source})
     upstream ${service.name}.${domain} {
+      least_conn;
     %   for server in service.servers:
-      server ${server.ip}:${server.port};
+      server ${server.ip}:${server.port} weight=${server.weight};
     %   endfor
     }
 

--- a/pen.cfg.tpl
+++ b/pen.cfg.tpl
@@ -1,7 +1,10 @@
 # ${service.name}:${service.port} (${service.source})
+% if service.application == 'http':
+http
+% endif
 % for server, i in zip(service.slots + [None] * (maxservers - len(service.slots)), range(maxservers)):
 %   if server:
-server ${i} address ${server.ip} port ${server.port} weight 1
+server ${i} address ${server.ip} port ${server.port} weight ${server.weight}
 %   else:
 server ${i} address 0.0.0.0 port 0 weight 0
 %   endif

--- a/pen.cfg.tpl
+++ b/pen.cfg.tpl
@@ -4,8 +4,8 @@ http
 % endif
 % for server, i in zip(service.slots + [None] * (maxservers - len(service.slots)), range(maxservers)):
 %   if server:
-server ${i} address ${server.ip} port ${server.port} weight ${server.weight}
+server ${i} address ${server.ip} port ${server.port} weight ${server.weight}${' max %s hard %s' % (server.maxconn, server.maxconn) if server.maxconn else ''}
 %   else:
-server ${i} address 0.0.0.0 port 0 weight 0
+server ${i} address 0.0.0.0 port 0 weight 0 max 0 hard 0
 %   endif
 % endfor

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 cachetools<2.0
 mako
 flake8
+mock

--- a/src/proxymatic/backend/haproxy.py
+++ b/src/proxymatic/backend/haproxy.py
@@ -3,9 +3,10 @@ import logging
 from proxymatic import util
 
 class HAProxyBackend(object):
-    def __init__(self, maxconnections, statusendpoint):
+    def __init__(self, maxconnections, statusendpoint, pidfile='/run/haproxy.pid'):
         self._maxconnections = maxconnections
         self._statusendpoint = statusendpoint
+        self._pidfile = pidfile
         self._prev = {}
         self._cfgfile = '/etc/haproxy/haproxy.cfg'
         self._render({})
@@ -23,10 +24,9 @@ class HAProxyBackend(object):
 
             # Instruct HAproxy to reload the config
             logging.debug("Reloaded the HAproxy config '%s'", self._cfgfile)
-            command = 'haproxy -f %s -p /run/haproxy.pid' % self._cfgfile
-            pidfile = '/run/haproxy.pid'
-            if os.path.exists(pidfile):
-                command += ' -sf ' + open(pidfile).read()
+            command = 'haproxy -f %s -p %s' % (self._cfgfile, self._pidfile)
+            if os.path.exists(self._pidfile):
+                command += ' -sf ' + open(self._pidfile).read()
             util.shell(command)
 
             # Remember the services that were rendered

--- a/src/proxymatic/discovery/marathon.py
+++ b/src/proxymatic/discovery/marathon.py
@@ -19,11 +19,12 @@ class MarathonService(object):
         self.priority = 100
 
 class MarathonDiscovery(object):
-    def __init__(self, backend, urls, interval):
+    def __init__(self, backend, urls, interval, groupsize=1):
         self._backend = backend
         self._urls = [url.rstrip('/') for url in urls]
         self._socketpath = '/tmp/marathon.sock'
         self._interval = interval
+        self._groupsize = groupsize
         self._healthy = False
         self._marathonService = MarathonService()
         self.priority = 10
@@ -133,12 +134,12 @@ class MarathonDiscovery(object):
 
         return ports
 
-    def _applyBackendAttributeInt(self, attribute, taskConfig, portIndex, server):
+    def _applyBackendAttributeInt(self, attribute, taskConfig, portIndex, server, divisor=1):
         attribKey = 'com.meltwater.proxymatic.port.%d.%s' % (portIndex, attribute)
         attribValue = util.rget(taskConfig, 'labels', attribKey)
         if attribValue is not None:
             if str(attribValue).isdigit():
-                setattr(server, attribute, int(attribValue))
+                setattr(server, attribute, int(attribValue) / divisor)
             else:
                 logging.warn("Weight %s=%s for task %s is not numeric ", attribKey, attribValue, taskConfig.get('id'))
 
@@ -224,7 +225,7 @@ class MarathonDiscovery(object):
 
                     # Set backend load balancer options
                     self._applyBackendAttributeInt('weight', taskConfig, portIndex, server)
-                    self._applyBackendAttributeInt('maxconn', taskConfig, portIndex, server)
+                    self._applyBackendAttributeInt('maxconn', taskConfig, portIndex, server, self._groupsize)
 
                     # Append backend to service
                     if key not in services:

--- a/src/proxymatic/discovery/registrator.py
+++ b/src/proxymatic/discovery/registrator.py
@@ -42,8 +42,8 @@ class RegistratorEtcdDiscovery(object):
         services = {}
         state = json.loads(content)
 
-        for node in util.rget(state, 'node', 'nodes'):
-            for backend in util.rget(node, 'nodes'):
+        for node in util.rget(state, 'node', 'nodes') or []:
+            for backend in util.rget(node, 'nodes') or []:
                 try:
                     parts = backend['key'].split(':')
                     port = int(parts[2])

--- a/src/proxymatic/main.py
+++ b/src/proxymatic/main.py
@@ -61,6 +61,11 @@ parser.add_option('--status-endpoint', dest='statusendpoint',
                   help='Expose /status endpoint and HAproxy stats on this ip:port [default: %default]. Specify an empty string to disable this endpoint',
                   default=os.environ.get('STATUS_ENDPOINT', '0.0.0.0:9090'))
 
+parser.add_option('--group-size', dest='groupsize',
+                  help='Number of Proxymatic instances serving this cluster. Per container connection ' +
+                       'limits are divided by this number to ensure a globally coordinated maxconn per container [default: %default]',
+                  type="int", default=parseint(os.environ.get('GROUP_SIZE', '1')))
+
 parser.add_option('--max-connections', dest='maxconnections',
                   help='Max number of connection per service [default: %default]',
                   type="int", default=parseint(os.environ.get('MAX_CONNECTIONS', '8192')))
@@ -120,7 +125,7 @@ if options.registrator:
     discovery.add(registrator)
 
 if options.marathon:
-    marathon = MarathonDiscovery(backend, parselist(options.marathon), options.interval)
+    marathon = MarathonDiscovery(backend, parselist(options.marathon), options.interval, options.groupsize)
     marathon.start()
     discovery.add(marathon)
 

--- a/src/proxymatic/services.py
+++ b/src/proxymatic/services.py
@@ -8,23 +8,30 @@ class Server(object):
         self.port = port
         self.hostname = hostname
         self.weight = 500
+        self.maxconn = None
 
     def __cmp__(self, other):
         if not isinstance(other, Server):
             return -1
-        return cmp((self.ip, self.port), (other.ip, other.port))
+        return cmp((self.ip, self.port, self.weight, self.maxconn), (other.ip, other.port, other.weight, other.maxconn))
 
     def __hash__(self):
-        return hash((self.ip, self.port))
+        return hash((self.ip, self.port, self.weight, self.maxconn))
 
     def __str__(self):
-        result = '%s:%s' % (self.ip, self.port)
+        extra = []
         if self.weight != 500:
-            result += "(%d)" % self.weight
+            extra.append("weight=%d" % self.weight)
+        if self.maxconn:
+            extra.append("maxconn=%d" % self.maxconn)
+
+        result = '%s:%s' % (self.ip, self.port)
+        if extra:
+            result += '(%s)' % ','.join(extra)
         return result
 
     def __repr__(self):
-        return 'Server(%s, %s, %s)' % (repr(self.ip), repr(self.port), repr(self.weight))
+        return 'Server(%s, %s, %s)' % (repr(self.ip), repr(self.port), repr(self.weight), repr(self.maxconn))
 
     def clone(self):
         return copy(self)
@@ -32,6 +39,11 @@ class Server(object):
     def setWeight(self, weight):
         clone = self.clone()
         clone.weight = weight
+        return clone
+
+    def setMaxconn(self, maxconn):
+        clone = self.clone()
+        clone.maxconn = maxconn
         return clone
 
 class Service(object):

--- a/src/proxymatic/services.py
+++ b/src/proxymatic/services.py
@@ -73,10 +73,10 @@ class Service(object):
     def __str__(self):
         return '%s:%s/%s -> [%s]' % (
             self.name, self.port, self.application if self.application != 'binary' else self.protocol,
-            ', '.join([str(s) for s in self.servers]))
+            ', '.join([str(s) for s in sorted(self.servers)]))
 
     def __repr__(self):
-        return 'Service(%s, %s, %s, %s, %s)' % (repr(self.name), repr(self.port), repr(self.protocol), repr(self.application), repr(self.servers))
+        return 'Service(%s, %s, %s, %s, %s)' % (repr(self.name), repr(self.port), repr(self.protocol), repr(self.application), repr(sorted(self.servers)))
 
     def __cmp__(self, other):
         if not isinstance(other, Service):

--- a/src/proxymatic/test.py
+++ b/src/proxymatic/test.py
@@ -2,6 +2,7 @@ import unittest
 import sys
 from proxymatic.test.haproxy_test import HAproxyTest
 from proxymatic.test.marathon_test import MarathonTest
+from proxymatic.test.services_test import ServicesTest
 from proxymatic.test.util_test import UtilTest
 
 if __name__ == '__main__':
@@ -9,6 +10,7 @@ if __name__ == '__main__':
 
     suite.addTest(unittest.makeSuite(HAproxyTest))
     suite.addTest(unittest.makeSuite(MarathonTest))
+    suite.addTest(unittest.makeSuite(ServicesTest))
     suite.addTest(unittest.makeSuite(UtilTest))
 
     res = not unittest.TextTestRunner(verbosity=2).run(suite).wasSuccessful()

--- a/src/proxymatic/test.py
+++ b/src/proxymatic/test.py
@@ -1,10 +1,14 @@
 import unittest
 import sys
+from proxymatic.test.haproxy_test import HAproxyTest
+from proxymatic.test.marathon_test import MarathonTest
 from proxymatic.test.util_test import UtilTest
 
 if __name__ == '__main__':
     suite = unittest.TestSuite()
 
+    suite.addTest(unittest.makeSuite(HAproxyTest))
+    suite.addTest(unittest.makeSuite(MarathonTest))
     suite.addTest(unittest.makeSuite(UtilTest))
 
     res = not unittest.TextTestRunner(verbosity=2).run(suite).wasSuccessful()

--- a/src/proxymatic/test/haproxy_test.py
+++ b/src/proxymatic/test/haproxy_test.py
@@ -8,6 +8,9 @@ from proxymatic.services import Service, Server
 from proxymatic.backend.haproxy import HAProxyBackend
 
 class HAproxyTest(unittest.TestCase):
+    def setUp(self):
+        random.seed(0)
+
     def testHAProxyReload(self):
         """
         Verifies that the HAproxy process is reloaded gracefully
@@ -39,8 +42,8 @@ listen demo.example-1234
   balance leastconn
   mode tcp
   default-server inter 15s
-  server backend-worker1-31001 1.2.3.4:31001 weight 128
   server backend-worker2-31002 2.2.3.4:31002 weight 128
+  server backend-worker1-31001 1.2.3.4:31001 weight 128
 """
         self._check(services, expected, pid=567)
 
@@ -85,12 +88,32 @@ listen demo.example-1234
 """
         self._check(services, expected)
 
+    def testConnectionLimits(self):
+        """
+        Verifies that backend weights are processed correctly
+        """
+        services = {
+            '1234/tcp': Service('example.demo', self, 1234, 'tcp').
+            addServer(Server('1.2.3.4', 31001, 'worker1').setMaxconn(150)).
+            addServer(Server('2.2.3.4', 31002, 'worker2'))
+        }
+
+        expected = """# example.demo (testConnectionLimits (proxymatic.test.haproxy_test.HAproxyTest))
+listen demo.example-1234
+  bind 0.0.0.0:1234
+  balance leastconn
+  mode tcp
+  default-server inter 15s
+  server backend-worker1-31001 1.2.3.4:31001 weight 128 maxconn 150
+  server backend-worker2-31002 2.2.3.4:31002 weight 128
+"""
+        self._check(services, expected)
+
     def _check(self, services, expected, pid=None):
         """
         Dummy reload of HAproxy and verifies that the rendered config contains the expected fragment
         """
         scope = {'rendered': None, 'count': 0}
-        random.seed(0)
 
         def render(src, dst, *args, **kwargs):
             if src == '/etc/haproxy/haproxy.cfg.tpl' and not os.path.exists('/etc/haproxy/haproxy.cfg.tpl'):

--- a/src/proxymatic/test/haproxy_test.py
+++ b/src/proxymatic/test/haproxy_test.py
@@ -1,0 +1,129 @@
+import os
+import random
+import unittest
+import tempfile
+from mock import patch
+from proxymatic.util import renderTemplate
+from proxymatic.services import Service, Server
+from proxymatic.backend.haproxy import HAProxyBackend
+
+class HAproxyTest(unittest.TestCase):
+    def testHAProxyReload(self):
+        """
+        Verifies that the HAproxy process is reloaded gracefully
+        """
+        services = {
+            '1234/tcp': Service('example.demo', self, 1234, 'tcp').
+            addServer(Server('1.2.3.4', 31001, 'worker1'))
+        }
+
+        expected = """# example.demo (testHAProxyReload (proxymatic.test.haproxy_test.HAproxyTest))
+listen demo.example-1234
+  bind 0.0.0.0:1234
+  balance leastconn
+  mode tcp
+  default-server inter 15s
+  server backend-worker1-31001 1.2.3.4:31001 weight 128
+"""
+        self._check(services, expected)
+
+        services = {
+            '1234/tcp': Service('example.demo', self, 1234, 'tcp').
+            addServer(Server('1.2.3.4', 31001, 'worker1')).
+            addServer(Server('2.2.3.4', 31002, 'worker2'))
+        }
+
+        expected = """# example.demo (testHAProxyReload (proxymatic.test.haproxy_test.HAproxyTest))
+listen demo.example-1234
+  bind 0.0.0.0:1234
+  balance leastconn
+  mode tcp
+  default-server inter 15s
+  server backend-worker1-31001 1.2.3.4:31001 weight 128
+  server backend-worker2-31002 2.2.3.4:31002 weight 128
+"""
+        self._check(services, expected, pid=567)
+
+    def testWeight(self):
+        """
+        Verifies that backend weights are processed correctly
+        """
+        services = {
+            '1234/tcp': Service('example.demo', self, 1234, 'tcp').
+            addServer(Server('1.2.3.4', 31001, 'worker1').setWeight(250)).
+            addServer(Server('2.2.3.4', 31002, 'worker2'))
+        }
+
+        expected = """# example.demo (testWeight (proxymatic.test.haproxy_test.HAproxyTest))
+listen demo.example-1234
+  bind 0.0.0.0:1234
+  balance leastconn
+  mode tcp
+  default-server inter 15s
+  server backend-worker1-31001 1.2.3.4:31001 weight 64
+  server backend-worker2-31002 2.2.3.4:31002 weight 128
+"""
+        self._check(services, expected)
+
+    def testLoadBalancerMode(self):
+        """
+        Verifies that HTTP mode can be enabled
+        """
+        services = {
+            '1234/tcp': Service('example.demo', self, 1234, 'tcp').
+            setApplication('http').
+            addServer(Server('1.2.3.4', 31001, 'worker1'))
+        }
+
+        expected = """# example.demo (testLoadBalancerMode (proxymatic.test.haproxy_test.HAproxyTest))
+listen demo.example-1234
+  bind 0.0.0.0:1234
+  balance leastconn
+  mode http
+  default-server inter 15s
+  server backend-worker1-31001 1.2.3.4:31001 weight 128
+"""
+        self._check(services, expected)
+
+    def _check(self, services, expected, pid=None):
+        """
+        Dummy reload of HAproxy and verifies that the rendered config contains the expected fragment
+        """
+        scope = {'rendered': None, 'count': 0}
+        random.seed(0)
+
+        def render(src, dst, *args, **kwargs):
+            if src == '/etc/haproxy/haproxy.cfg.tpl' and not os.path.exists('/etc/haproxy/haproxy.cfg.tpl'):
+                src = os.path.dirname(__file__) + '/../../../haproxy.cfg.tpl'
+
+            scope['rendered'] = renderTemplate(src, '/dev/null', *args, **kwargs)
+            scope['count'] += 1
+            return scope['rendered']
+
+        with patch('proxymatic.util.shell') as shell_mock:
+            # Write out the pid
+            if pid:
+                tmpfile = tempfile.NamedTemporaryFile()
+                pidfile = tmpfile.name
+                with open(pidfile, 'w') as pd:
+                    pd.write(str(pid))
+            else:
+                pidfile = '/tmp/proxymatic-haproxy-test.pid'
+
+            # Render the config
+            with patch('proxymatic.util.renderTemplate', wraps=render):
+                backend = HAProxyBackend(8092, '0.0.0.0:9090', pidfile)
+                backend.update(self, services)
+
+                try:
+                    self.assertIn(expected, scope['rendered'])
+                    self.assertEquals(2, scope['count'])
+                except:
+                    print scope['rendered']
+                    raise
+
+            # Check that HAproxy was reloaded correctly
+            command = 'haproxy -f /etc/haproxy/haproxy.cfg -p ' + pidfile
+            if pid:
+                command += ' -sf %s' % pid
+            self.assertIn(command, shell_mock.call_args[0][0])

--- a/src/proxymatic/test/marathon/testCanary/_v2_apps_demo_webapp-canary_versions_2016-10-04T12:58:17.435Z.json
+++ b/src/proxymatic/test/marathon/testCanary/_v2_apps_demo_webapp-canary_versions_2016-10-04T12:58:17.435Z.json
@@ -1,0 +1,38 @@
+{
+  "id": "/demo/webapp-canary",
+  "ports": [
+    10000
+  ],
+  "portDefinitions": [
+    {
+      "port": 10000,
+      "protocol": "tcp",
+      "labels": {}
+    }
+  ],
+  "healthChecks": [
+    {
+      "path": "/_status",
+      "protocol": "HTTP",
+      "portIndex": 0,
+      "gracePeriodSeconds": 150,
+      "intervalSeconds": 15,
+      "timeoutSeconds": 5,
+      "maxConsecutiveFailures": 3,
+      "ignoreHttp1xx": false
+    }
+  ],
+  "readinessChecks": [],
+  "dependencies": [],
+  "upgradeStrategy": {
+    "minimumHealthCapacity": 1,
+    "maximumOverCapacity": 1
+  },
+  "labels": {
+    "com.meltwater.proxymatic.port.0.servicePort": "1234",
+    "com.meltwater.proxymatic.port.0.weight": "100",
+    "com.meltwater.proxymatic.port.0.mode": "http"
+  },
+  "ipAddress": null,
+  "version": "2016-10-04T12:58:17.435Z"
+}

--- a/src/proxymatic/test/marathon/testCanary/_v2_apps_demo_webapp_versions_2016-10-04T12:48:17.435Z.json
+++ b/src/proxymatic/test/marathon/testCanary/_v2_apps_demo_webapp_versions_2016-10-04T12:48:17.435Z.json
@@ -1,0 +1,36 @@
+{
+  "id": "/demo/webapp",
+  "ports": [
+    1234
+  ],
+  "portDefinitions": [
+    {
+      "port": 1234,
+      "protocol": "tcp",
+      "labels": {}
+    }
+  ],
+  "healthChecks": [
+    {
+      "path": "/_status",
+      "protocol": "HTTP",
+      "portIndex": 0,
+      "gracePeriodSeconds": 150,
+      "intervalSeconds": 15,
+      "timeoutSeconds": 5,
+      "maxConsecutiveFailures": 3,
+      "ignoreHttp1xx": false
+    }
+  ],
+  "readinessChecks": [],
+  "dependencies": [],
+  "upgradeStrategy": {
+    "minimumHealthCapacity": 1,
+    "maximumOverCapacity": 1
+  },
+  "labels": {
+    "com.meltwater.proxymatic.port.0.mode": "http"
+  },
+  "ipAddress": null,
+  "version": "2016-10-04T12:48:17.435Z"
+}

--- a/src/proxymatic/test/marathon/testCanary/_v2_tasks.json
+++ b/src/proxymatic/test/marathon/testCanary/_v2_tasks.json
@@ -1,0 +1,40 @@
+{
+  "tasks": [
+    {
+      "id": "demo_webapp.d35bf0f3-8a30-11e6-a4fe-dec283d23ff6",
+      "host": "localhost",
+      "ports": [
+        31468
+      ],
+      "version": "2016-10-04T12:48:17.435Z",
+      "appId": "/demo/webapp",
+      "servicePorts": [
+        1234
+      ],
+      "healthCheckResults": [
+        {
+          "alive": true,
+          "consecutiveFailures": 0
+        }
+      ]
+    },
+    {
+      "id": "demo_webapp-canary.e35bf0f3-8a30-11e6-a4fe-dec283d23ff6",
+      "host": "localhost",
+      "ports": [
+        31469
+      ],
+      "version": "2016-10-04T12:58:17.435Z",
+      "appId": "/demo/webapp-canary",
+      "servicePorts": [
+        10000
+      ],
+      "healthCheckResults": [
+        {
+          "alive": true,
+          "consecutiveFailures": 0
+        }
+      ]
+    }    
+  ]
+}

--- a/src/proxymatic/test/marathon/testLoadBalancerOptions/_v2_apps_demo_webapp-canary_versions_2016-10-04T12:58:17.435Z.json
+++ b/src/proxymatic/test/marathon/testLoadBalancerOptions/_v2_apps_demo_webapp-canary_versions_2016-10-04T12:58:17.435Z.json
@@ -1,0 +1,37 @@
+{
+  "id": "/demo/webapp-canary",
+  "ports": [
+    10000
+  ],
+  "portDefinitions": [
+    {
+      "port": 10000,
+      "protocol": "tcp",
+      "labels": {}
+    }
+  ],
+  "healthChecks": [
+    {
+      "path": "/_status",
+      "protocol": "HTTP",
+      "portIndex": 0,
+      "gracePeriodSeconds": 150,
+      "intervalSeconds": 15,
+      "timeoutSeconds": 5,
+      "maxConsecutiveFailures": 3,
+      "ignoreHttp1xx": false
+    }
+  ],
+  "readinessChecks": [],
+  "dependencies": [],
+  "upgradeStrategy": {
+    "minimumHealthCapacity": 1,
+    "maximumOverCapacity": 1
+  },
+  "labels": {
+    "com.meltwater.proxymatic.port.0.servicePort": "1234",
+    "com.meltwater.proxymatic.port.0.mode": "http"
+  },
+  "ipAddress": null,
+  "version": "2016-10-04T12:58:17.435Z"
+}

--- a/src/proxymatic/test/marathon/testLoadBalancerOptions/_v2_apps_demo_webapp_versions_2016-10-04T12:48:17.435Z.json
+++ b/src/proxymatic/test/marathon/testLoadBalancerOptions/_v2_apps_demo_webapp_versions_2016-10-04T12:48:17.435Z.json
@@ -1,0 +1,38 @@
+{
+  "id": "/demo/webapp",
+  "ports": [
+    1234
+  ],
+  "portDefinitions": [
+    {
+      "port": 1234,
+      "protocol": "tcp",
+      "labels": {}
+    }
+  ],
+  "healthChecks": [
+    {
+      "path": "/_status",
+      "protocol": "HTTP",
+      "portIndex": 0,
+      "gracePeriodSeconds": 150,
+      "intervalSeconds": 15,
+      "timeoutSeconds": 5,
+      "maxConsecutiveFailures": 3,
+      "ignoreHttp1xx": false
+    }
+  ],
+  "readinessChecks": [],
+  "dependencies": [],
+  "upgradeStrategy": {
+    "minimumHealthCapacity": 1,
+    "maximumOverCapacity": 1
+  },
+  "labels": {
+    "com.meltwater.proxymatic.port.0.weight": "100",
+    "com.meltwater.proxymatic.port.0.maxconn": "150",
+    "com.meltwater.proxymatic.port.0.mode": "http"
+  },
+  "ipAddress": null,
+  "version": "2016-10-04T12:48:17.435Z"
+}

--- a/src/proxymatic/test/marathon/testLoadBalancerOptions/_v2_tasks.json
+++ b/src/proxymatic/test/marathon/testLoadBalancerOptions/_v2_tasks.json
@@ -1,0 +1,40 @@
+{
+  "tasks": [
+    {
+      "id": "demo_webapp.d35bf0f3-8a30-11e6-a4fe-dec283d23ff6",
+      "host": "localhost",
+      "ports": [
+        31468
+      ],
+      "version": "2016-10-04T12:48:17.435Z",
+      "appId": "/demo/webapp",
+      "servicePorts": [
+        1234
+      ],
+      "healthCheckResults": [
+        {
+          "alive": true,
+          "consecutiveFailures": 0
+        }
+      ]
+    },
+    {
+      "id": "demo_webapp-canary.e35bf0f3-8a30-11e6-a4fe-dec283d23ff6",
+      "host": "localhost",
+      "ports": [
+        31469
+      ],
+      "version": "2016-10-04T12:58:17.435Z",
+      "appId": "/demo/webapp-canary",
+      "servicePorts": [
+        10000
+      ],
+      "healthCheckResults": [
+        {
+          "alive": true,
+          "consecutiveFailures": 0
+        }
+      ]
+    }    
+  ]
+}

--- a/src/proxymatic/test/marathon/testRefresh/_v2_apps_demo_webapp_versions_2016-10-04T12:48:17.435Z.json
+++ b/src/proxymatic/test/marathon/testRefresh/_v2_apps_demo_webapp_versions_2016-10-04T12:48:17.435Z.json
@@ -1,0 +1,35 @@
+{
+  "id": "/demo/webapp",
+  "ports": [
+    1234
+  ],
+  "portDefinitions": [
+    {
+      "port": 1234,
+      "protocol": "tcp",
+      "labels": {}
+    }
+  ],
+  "healthChecks": [
+    {
+      "path": "/_status",
+      "protocol": "HTTP",
+      "portIndex": 0,
+      "gracePeriodSeconds": 150,
+      "intervalSeconds": 15,
+      "timeoutSeconds": 5,
+      "maxConsecutiveFailures": 3,
+      "ignoreHttp1xx": false
+    }
+  ],
+  "readinessChecks": [],
+  "dependencies": [],
+  "upgradeStrategy": {
+    "minimumHealthCapacity": 1,
+    "maximumOverCapacity": 1
+  },
+  "labels": {
+  },
+  "ipAddress": null,
+  "version": "2016-10-04T12:48:17.435Z"
+}

--- a/src/proxymatic/test/marathon/testRefresh/_v2_tasks_0.json
+++ b/src/proxymatic/test/marathon/testRefresh/_v2_tasks_0.json
@@ -1,0 +1,22 @@
+{
+  "tasks": [
+    {
+      "id": "demo_webapp.d35bf0f3-8a30-11e6-a4fe-dec283d23ff6",
+      "host": "localhost",
+      "ports": [
+        31478
+      ],
+      "version": "2016-10-04T12:48:17.435Z",
+      "appId": "/demo/webapp",
+      "servicePorts": [
+        1234
+      ],
+      "healthCheckResults": [
+        {
+          "alive": true,
+          "consecutiveFailures": 0
+        }
+      ]
+    }
+  ]
+}

--- a/src/proxymatic/test/marathon/testRefresh/_v2_tasks_1.json
+++ b/src/proxymatic/test/marathon/testRefresh/_v2_tasks_1.json
@@ -1,0 +1,40 @@
+{
+  "tasks": [
+    {
+      "id": "demo_webapp.d35bf0f3-8a30-11e6-a4fe-dec283d23ff6",
+      "host": "localhost",
+      "ports": [
+        31478
+      ],
+      "version": "2016-10-04T12:48:17.435Z",
+      "appId": "/demo/webapp",
+      "servicePorts": [
+        1234
+      ],
+      "healthCheckResults": [
+        {
+          "alive": true,
+          "consecutiveFailures": 0
+        }
+      ]
+    },
+    {
+      "id": "demo_webapp.e35bf0f3-8a30-11e6-a4fe-dec283d23ff6",
+      "host": "localhost",
+      "ports": [
+        31479
+      ],
+      "version": "2016-10-04T12:48:17.435Z",
+      "appId": "/demo/webapp",
+      "servicePorts": [
+        1234
+      ],
+      "healthCheckResults": [
+        {
+          "alive": true,
+          "consecutiveFailures": 0
+        }
+      ]
+    }    
+  ]
+}

--- a/src/proxymatic/test/marathon_test.py
+++ b/src/proxymatic/test/marathon_test.py
@@ -1,0 +1,75 @@
+import os
+import unittest
+from mock import patch
+from proxymatic.discovery.marathon import MarathonDiscovery, getAppVersion
+
+def fileserver(path):
+    counts = {}
+
+    def handler(method, socketpath, url, body=None, headers={}):
+        # Try to read response for this sequence number
+        filename = '%s%s_%s.json' % (path, url.replace('/', '_'), counts.get(url, 0))
+        if not os.path.exists(filename):
+            filename = '%s%s.json' % (path, url.replace('/', '_'))
+        counts[url] = counts.get(url, 0) + 1
+
+        if method == 'GET':
+            if os.path.exists(filename):
+                return open(filename).read()
+            raise ValueError("Unknown test HTTP endpoint %s (expected test file %s)" % (url, filename))
+
+        raise ValueError("Unsupported HTTP method %s" % method)
+
+    return handler
+
+class TestBackend(object):
+    def __init__(self):
+        self.source = None
+        self.services = {}
+        self.updatedCount = 0
+
+    def update(self, source, services):
+        self.source = source
+        self.services = services
+        self.updatedCount += 1
+
+class MarathonTest(unittest.TestCase):
+    def setUp(self):
+        # Clear the response cache to avoid interference between tests
+        getAppVersion.cache_clear()
+
+    def testMarathonLoadBalancer(self):
+        backend = TestBackend()
+        MarathonDiscovery(backend, ['http://1.2.3.4:8080/', 'http://1.2.3.5:8080/'], 15)
+        self.assertEquals(1, backend.updatedCount)
+        self.assertEquals(
+            "marathon:/tmp/marathon.sock/http -> [1.2.3.4:8080, 1.2.3.5:8080]",
+            str(backend.services['/tmp/marathon.sock']))
+
+    @patch('proxymatic.util.unixrequest', wraps=fileserver(os.path.dirname(__file__) + '/marathon/testRefresh/'))
+    def testRefresh(self, unixrequest_mock):
+        backend = TestBackend()
+        discovery = MarathonDiscovery(backend, ['http://1.2.3.4:8080/'], 15)
+
+        discovery._refresh()
+        self.assertEquals(2, backend.updatedCount)
+        self.assertEquals(
+            "webapp.demo:1234/tcp -> [127.0.0.1:31478]",
+            str(backend.services['1234/tcp']))
+
+        discovery._refresh()
+        self.assertEquals(3, backend.updatedCount)
+        self.assertEquals(
+            "webapp.demo:1234/tcp -> [127.0.0.1:31479, 127.0.0.1:31478]",
+            str(backend.services['1234/tcp']))
+
+    @patch('proxymatic.util.unixrequest', wraps=fileserver(os.path.dirname(__file__) + '/marathon/testCanary/'))
+    def testCanary(self, unixrequest_mock):
+        backend = TestBackend()
+        discovery = MarathonDiscovery(backend, ['http://1.2.3.4:8080/'], 15)
+
+        discovery._refresh()
+        self.assertEquals(2, backend.updatedCount)
+        self.assertEquals(
+            "webapp.demo:1234/http -> [127.0.0.1:31468, 127.0.0.1:31469(100)]",
+            str(backend.services['1234/tcp']))

--- a/src/proxymatic/test/marathon_test.py
+++ b/src/proxymatic/test/marathon_test.py
@@ -45,7 +45,7 @@ class MarathonTest(unittest.TestCase):
         MarathonDiscovery(backend, ['http://1.2.3.4:8080/', 'http://1.2.3.5:8080/'], 15)
         self.assertEquals(1, backend.updatedCount)
         self.assertEquals(
-            "marathon:/tmp/marathon.sock/http -> [1.2.3.5:8080, 1.2.3.4:8080]",
+            "marathon:/tmp/marathon.sock/http -> [1.2.3.4:8080, 1.2.3.5:8080]",
             str(backend.services['/tmp/marathon.sock']))
 
     @patch('proxymatic.util.unixrequest', wraps=fileserver(os.path.dirname(__file__) + '/marathon/testRefresh/'))
@@ -62,7 +62,7 @@ class MarathonTest(unittest.TestCase):
         discovery._refresh()
         self.assertEquals(3, backend.updatedCount)
         self.assertEquals(
-            "webapp.demo:1234/tcp -> [127.0.0.1:31479, 127.0.0.1:31478]",
+            "webapp.demo:1234/tcp -> [127.0.0.1:31478, 127.0.0.1:31479]",
             str(backend.services['1234/tcp']))
 
     @patch('proxymatic.util.unixrequest', wraps=fileserver(os.path.dirname(__file__) + '/marathon/testCanary/'))
@@ -73,7 +73,7 @@ class MarathonTest(unittest.TestCase):
         discovery._refresh()
         self.assertEquals(2, backend.updatedCount)
         self.assertEquals(
-            "webapp.demo:1234/http -> [127.0.0.1:31469(weight=100), 127.0.0.1:31468]",
+            "webapp.demo:1234/http -> [127.0.0.1:31468, 127.0.0.1:31469(weight=100)]",
             str(backend.services['1234/tcp']))
 
     @patch('proxymatic.util.unixrequest', wraps=fileserver(os.path.dirname(__file__) + '/marathon/testLoadBalancerOptions/'))
@@ -84,5 +84,5 @@ class MarathonTest(unittest.TestCase):
         discovery._refresh()
         self.assertEquals(2, backend.updatedCount)
         self.assertEquals(
-            "webapp.demo:1234/http -> [127.0.0.1:31469, 127.0.0.1:31468(weight=100,maxconn=150)]",
+            "webapp.demo:1234/http -> [127.0.0.1:31468(weight=100,maxconn=150), 127.0.0.1:31469]",
             str(backend.services['1234/tcp']))

--- a/src/proxymatic/test/services_test.py
+++ b/src/proxymatic/test/services_test.py
@@ -1,0 +1,10 @@
+import unittest
+from proxymatic.services import Server
+
+class ServicesTest(unittest.TestCase):
+    def testServerCmp(self):
+        server = Server('127.0.0.1', 5432, 'localhost')
+        self.assertEqual(server, server.clone())
+        self.assertEqual(server.setWeight(250), server.setWeight(250).clone())
+        self.assertNotEqual(server, server.setWeight(250))
+        self.assertNotEqual(server, server.setMaxconn(150))

--- a/src/proxymatic/util.py
+++ b/src/proxymatic/util.py
@@ -140,13 +140,17 @@ def unixrequest(method, socketpath, url, body=None, headers={}):
 def renderTemplate(src, dst, vals):
     template = Template(filename=src)
     config = template.render(**vals)
-    tmpfile = "%s.tmp" % dst
-    with open(tmpfile, 'w') as f:
-        f.write(config)
 
-    # Rename tmpfile to avoid modifying an existing file in place which can
-    # cause a process reading it concurrent to read inconsistent data
-    os.rename(tmpfile, dst)
+    if dst != '/dev/null':
+        tmpfile = "%s.tmp" % dst
+        with open(tmpfile, 'w') as f:
+            f.write(config)
+
+        # Rename tmpfile to avoid modifying an existing file in place which can
+        # cause a process reading it concurrent to read inconsistent data
+        os.rename(tmpfile, dst)
+
+    return config
 
 def jitter(duration):
     return duration * (0.75 + random.random() * 0.25)


### PR DESCRIPTION
Support overriding load balancer mode (tcp,http), backend weight, maxconns and servicePort per service. This enables canarying where multiple Marathon apps are load balanced on the same servicePort. 
- Added unit tests for Marathon and HAproxy integrations
