### PR TITLE
[WIP] HAproxy health checking and traffic slow starting

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Applications may set Marathon labels to override load balancer settings for each
     "com.meltwater.proxymatic.0.servicePort": "1234",
     "com.meltwater.proxymatic.0.weight": "100",
     "com.meltwater.proxymatic.0.maxconn": "200",
+    "com.meltwater.proxymatic.0.slowstart": "15",
     "com.meltwater.proxymatic.0.mode": "http"
   }
 ```
@@ -177,6 +178,7 @@ Applications may set Marathon labels to override load balancer settings for each
 | com.meltwater.proxymatic.&lt;N&gt;.servicePort | Override the service port for this exposed container port |
 | com.meltwater.proxymatic.&lt;N&gt;.weight | Weight for the containers of this app version in the range `1-1000`. Default value is `500`. |
 | com.meltwater.proxymatic.&lt;N&gt;.maxconn | Maximum concurrent connections per container. |
+| com.meltwater.proxymatic.&lt;N&gt;.slowstart | Slow start gradually of this number of seconds. Rampup is done in steps of health check intervalSeconds. |
 | com.meltwater.proxymatic.&lt;N&gt;.mode | Load balancer mode for this port as either `tcp` or `http`. Default is `tcp` mode. |
 
 ## Deployment

--- a/haproxy.cfg.tpl
+++ b/haproxy.cfg.tpl
@@ -87,7 +87,7 @@ listen ${service.marathonpath}-${service.portname}
   default-server inter 15s
 % 	for server in service.slots:
 %     if server:
-  server backend-${server.hostname}-${server.port} ${server.ip}:${server.port} weight ${int(float(server.weight) / 1000.0 * 256.0)}${' maxconn %s' % server.maxconn if server.maxconn else ''}${' check' if service.healthcheck else ''}
+  server backend-${server.hostname}-${server.port} ${server.ip}:${server.port} weight ${int(float(server.weight) / 1000.0 * 256.0)}${' maxconn %s' % server.maxconn if server.maxconn else ''}${' slowstart %ss' % server.slowstart if server.slowstart else ''}${' check' if service.healthcheck else ''}
 %     endif
 % 	endfor  
 

--- a/src/proxymatic/discovery/marathon.py
+++ b/src/proxymatic/discovery/marathon.py
@@ -226,6 +226,7 @@ class MarathonDiscovery(object):
                     # Set backend load balancer options
                     self._applyBackendAttributeInt('weight', taskConfig, portIndex, server)
                     self._applyBackendAttributeInt('maxconn', taskConfig, portIndex, server, self._groupsize)
+                    self._applyBackendAttributeInt('slowstart', taskConfig, portIndex, server)
 
                     # Append backend to service
                     if key not in services:

--- a/src/proxymatic/discovery/marathon.py
+++ b/src/proxymatic/discovery/marathon.py
@@ -227,6 +227,10 @@ class MarathonDiscovery(object):
                     self._applyBackendAttributeInt('weight', taskConfig, portIndex, server)
                     self._applyBackendAttributeInt('maxconn', taskConfig, portIndex, server, self._groupsize)
                     self._applyBackendAttributeInt('slowstart', taskConfig, portIndex, server)
+                    # Haproxy requires both slowstart and healthcheck to work
+                    if server.slowstart and not healthChecks:
+                        logging.warn("Failed to add slowstart for service %s backend %s: %s, healthcheck is required for slowstart", task.get('appId', ''), task.get('id', ''), str(e))
+                        server.slowstart = None
 
                     # Append backend to service
                     if key not in services:

--- a/src/proxymatic/services.py
+++ b/src/proxymatic/services.py
@@ -7,16 +7,23 @@ class Server(object):
         self.ip = ip
         self.port = port
         self.hostname = hostname
+
+        # Relative weight for this server in the range 0-1000
         self.weight = 500
+
+        # Max connections for this server, default is unlimited
         self.maxconn = None
+
+        # Slow start time in seconds, default is no slow start
+        self.slowstart = None
 
     def __cmp__(self, other):
         if not isinstance(other, Server):
             return -1
-        return cmp((self.ip, self.port, self.weight, self.maxconn), (other.ip, other.port, other.weight, other.maxconn))
+        return cmp((self.ip, self.port, self.weight, self.maxconn, self.slowstart), (other.ip, other.port, other.weight, other.maxconn, self.slowstart))
 
     def __hash__(self):
-        return hash((self.ip, self.port, self.weight, self.maxconn))
+        return hash((self.ip, self.port, self.weight, self.maxconn, self.slowstart))
 
     def __str__(self):
         extra = []
@@ -24,6 +31,8 @@ class Server(object):
             extra.append("weight=%d" % self.weight)
         if self.maxconn:
             extra.append("maxconn=%d" % self.maxconn)
+        if self.slowstart:
+            extra.append("slowstart=%d" % self.slowstart)
 
         result = '%s:%s' % (self.ip, self.port)
         if extra:
@@ -31,7 +40,7 @@ class Server(object):
         return result
 
     def __repr__(self):
-        return 'Server(%s, %s, %s)' % (repr(self.ip), repr(self.port), repr(self.weight), repr(self.maxconn))
+        return 'Server(%s, %s, %s)' % (repr(self.ip), repr(self.port), repr(self.weight), repr(self.maxconn), repr(self.slowstart))
 
     def clone(self):
         return copy(self)
@@ -44,6 +53,11 @@ class Server(object):
     def setMaxconn(self, maxconn):
         clone = self.clone()
         clone.maxconn = maxconn
+        return clone
+
+    def setSlowstart(self, slowstart):
+        clone = self.clone()
+        clone.slowstart = slowstart
         return clone
 
 class Service(object):

--- a/src/proxymatic/test/marathon/testLoadBalancerOptions/_v2_apps_demo_webapp-canary_versions_2016-10-04T12:58:17.435Z.json
+++ b/src/proxymatic/test/marathon/testLoadBalancerOptions/_v2_apps_demo_webapp-canary_versions_2016-10-04T12:58:17.435Z.json
@@ -30,6 +30,7 @@
   },
   "labels": {
     "com.meltwater.proxymatic.port.0.servicePort": "1234",
+    "com.meltwater.proxymatic.port.0.slowstart": "15",
     "com.meltwater.proxymatic.port.0.mode": "http"
   },
   "ipAddress": null,

--- a/src/proxymatic/test/marathon_test.py
+++ b/src/proxymatic/test/marathon_test.py
@@ -84,5 +84,5 @@ class MarathonTest(unittest.TestCase):
         discovery._refresh()
         self.assertEquals(2, backend.updatedCount)
         self.assertEquals(
-            "webapp.demo:1234/http -> [127.0.0.1:31468(weight=100,maxconn=150), 127.0.0.1:31469]",
+            "webapp.demo:1234/http -> [127.0.0.1:31468(weight=100,maxconn=150), 127.0.0.1:31469(slowstart=15)]",
             str(backend.services['1234/tcp']))


### PR DESCRIPTION
* TODO: interprete Marathon health checks and have HAproxy perform the same checks to ensure connectivity between load balancer machine and Mesos slave
* Slowstart parameter to ramp up traffic gradually to allow containers (and JVM's in particular) time to warm up

**don't merge yet, this is a work in progress**